### PR TITLE
ci: Add Pull Request Title Checking

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,27 @@
+name: "Pull Request Checks"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate checks on pull request titles. The workflow ensures that the titles follow a specified format, improving consistency and readability.

Workflow setup:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR1-R27): Added a new workflow named "Pull Request Checks" that triggers on various pull request events (e.g., opened, edited, labeled). The workflow includes a job to check if the pull request title starts with an allowed prefix, using the `deepakputhraya/action-pr-title` GitHub Action.

Fixes #17