### PR TITLE
ci: Add Python Setup Dependencies Composite Action

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -1,0 +1,22 @@
+name: "Setup Dependencies"
+description: "Installs dependencies for the project"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry==1.8.4
+
+    - name: Install Python 3.13 with Poetry Cache
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version-file: "pyproject.toml"
+        cache: "poetry"
+
+    - name: Set up Just
+      uses: extractions/setup-just@v2
+
+    - name: Install Poetry Dependencies
+      shell: bash
+      run: just install


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Action to set up dependencies for the project. The action installs Poetry, sets up Python with Poetry cache, and installs project dependencies using Just.

Key changes include:

* **New GitHub Action**:
  * Added a new action named "Setup Dependencies" to install necessary dependencies for the project. (`.github/actions/setup-dependencies/action.yml`)
  * Steps included in the action:
    * Install Poetry version 1.8.4 using `pipx`.
    * Install Python 3.13 with Poetry cache using `actions/setup-python@v5.3.0`.
    * Set up Just using `extractions/setup-just@v2`.
    * Install Poetry dependencies using Just.

Fixes #36
