### PR TITLE
chore: Fix Long Line Warnings

### DIFF
--- a/scanner/utils/tests/test_read_markdown.py
+++ b/scanner/utils/tests/test_read_markdown.py
@@ -49,7 +49,7 @@ def test_find_table_data_start_index() -> None:
         "",
         "This project uses the following technologies and frameworks:",
         "",
-        "| Catagory | Technologies and Frameworks                                                                                                                                                                                                                             |",  # noqa: E501
+        "| Category | Technologies and Frameworks                                                                                                                                                                                                                             |",  # noqa: E501
         "| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |",  # noqa: E501
         "| Frontend | ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white) ![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)                      |",  # noqa: E501
         "| Backend  | ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) ![Poetry](https://img.shields.io/badge/poetry-%23150458.svg?style=for-the-badge&logo=poetry&logoColor=white)                                     |",  # noqa: E501

--- a/scanner/utils/tests/test_read_markdown.py
+++ b/scanner/utils/tests/test_read_markdown.py
@@ -49,11 +49,11 @@ def test_find_table_data_start_index() -> None:
         "",
         "This project uses the following technologies and frameworks:",
         "",
-        "| Catagory | Technologies and Frameworks                                                                                                                                                                                                                             |",
-        "| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |",
-        "| Frontend | ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white) ![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)                      |",
-        "| Backend  | ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) ![Poetry](https://img.shields.io/badge/poetry-%23150458.svg?style=for-the-badge&logo=poetry&logoColor=white)                                     |",
-        "| CI/CD    | ![Dependabot](https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white) |",
+        "| Catagory | Technologies and Frameworks                                                                                                                                                                                                                             |",  # noqa: E501
+        "| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |",  # noqa: E501
+        "| Frontend | ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white) ![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)                      |",  # noqa: E501
+        "| Backend  | ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) ![Poetry](https://img.shields.io/badge/poetry-%23150458.svg?style=for-the-badge&logo=poetry&logoColor=white)                                     |",  # noqa: E501
+        "| CI/CD    | ![Dependabot](https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white) |",  # noqa: E501
         "",
     ]
     # Act
@@ -66,15 +66,21 @@ def test_find_table_data_start_index() -> None:
     ("line_contents", "expected"),
     [
         (
-            "| Frontend | ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white) ![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)                      |",
+            "| Frontend | ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript"
+            "&logoColor=white) ![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro"
+            "&logoColor=white)                      |",
             ["TypeScript", "Astro"],
         ),
         (
-            "| Backend  | ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) ![Poetry](https://img.shields.io/badge/poetry-%23150458.svg?style=for-the-badge&logo=poetry&logoColor=white)                                     |",
+            "| Backend  | ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python"
+            "&logoColor=ffdd54) ![Poetry](https://img.shields.io/badge/poetry-%23150458.svg?style=for-the-badge"
+            "&logo=poetry&logoColor=white)                                     |",
             ["Python", "Poetry"],
         ),
         (
-            "| CI/CD    | ![Dependabot](https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white) |",
+            "| CI/CD    | ![Dependabot](https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot"
+            "&logoColor=white) ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge"
+            "&logo=githubactions&logoColor=white) |",
             ["Dependabot", "GitHub Actions"],
         ),
         ("", []),


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `test_find_table_data_start_index` function in the `scanner/utils/tests/test_read_markdown.py` file. The modifications primarily focus on improving code readability and adhering to linting rules.

Code readability improvements:

* Added `# noqa: E501` comments to long lines in the markdown table to suppress line length warnings.

Adhering to linting rules:

* Split long URLs into multiple lines to comply with line length limits.

Fixes #45 
