### PR TITLE
ci: Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -144,3 +144,18 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Check Justfile Format
+        run: just just-format-check

--- a/Justfile
+++ b/Justfile
@@ -92,11 +92,11 @@ prettier-format:
 # ------------------------------------------------------------------------------
 
 # Format the Just code
-format:
+just-format:
     just --fmt --unstable
 
 # Check for Just format issues
-format-check:
+just-format-check:
     just --fmt --check --unstable
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to ensure the correct formatting of the `Justfile`.

* Added `check-justfile-format` job to `.github/workflows/code-checks.yml` to automate the process of checking the `Justfile` format. This job includes steps to checkout the repository, set up Just, and run the format check.

Fixes #18 
