### PR TITLE
build: Deploy GitHub Pages

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+
+      - name: Run Scanner
+        run: just run
+        env:
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+
+      - name: Make GitHub Pages Directory
+        run: mkdir -p pages
+
+      - name: Copy Files to GitHub Pages Directory
+        run: cp -r tech_report.md pages
+
+      - name: Upload GitHub Pages Directory
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: pages/
+
+  deploy:
+    needs: build
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate the deployment of the project to GitHub Pages. The workflow is triggered on pushes to the main branch and can also be manually triggered.

Key changes include:

* Added a new workflow file `.github/workflows/deploy-to-github-pages.yml` to define the deployment process.

Workflow details:

* The workflow is named "Deploy to GitHub Pages" and is triggered on pushes to the main branch and via manual dispatch.
* The workflow includes two jobs: `build` and `deploy`.
* The `build` job sets up the environment, runs a scanner, and prepares the files for deployment.
* The `deploy` job uploads the prepared files to GitHub Pages.

Fixes #51 
