### PR TITLE
build: Move tech_report.md to index.md

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -34,7 +34,7 @@ jobs:
         run: mkdir -p pages
 
       - name: Copy Files to GitHub Pages Directory
-        run: cp -r tech_report.md pages
+        run: cp -r tech_report.md pages/index.md
 
       - name: Upload GitHub Pages Directory
         uses: actions/upload-pages-artifact@v3.0.1


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy-to-github-pages.yml` file. The change ensures that the `tech_report.md` file is copied to `pages/index.md` instead of just `pages`.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL37-R37): Modified the file copy step to rename `tech_report.md` to `index.md` in the `pages` directory.

Fixes #59 
