### PR TITLE
build: Migrate to Jekyll

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -30,16 +30,15 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
-      - name: Make GitHub Pages Directory
-        run: mkdir -p pages
+      - name: Build
+        uses: actions/jekyll-build-pages@v1.0.13
+        with:
+          destination: "./output"
 
-      - name: Copy Files to GitHub Pages Directory
-        run: cp -r tech_report.md pages/index.md
-
-      - name: Upload GitHub Pages Directory
+      - name: Upload artifact
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          path: pages/
+          path: "./output"
 
   deploy:
     needs: build

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: Build
+    name: Build GitHub Pages
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow for deploying to GitHub Pages. The most important changes include renaming the build job, replacing manual steps with a Jekyll action for building the site, and updating the artifact upload path.

Changes to the build job:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL16-R16): Renamed the build job to "Build GitHub Pages".

Changes to the build steps:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL33-R41): Replaced manual steps for creating and copying files to the GitHub Pages directory with the `actions/jekyll-build-pages` action.
* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL33-R41): Updated the artifact upload path to match the new build output directory.

Fixes #61 
