### PR TITLE
chore: Group GitHub Action Dependabot Pull Requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    groups:
+    github-actions:
+      patterns:
+        - "*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change adds a grouping for GitHub Actions updates. 

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R16): Added a `groups` section to group GitHub Actions updates under `github-actions` with a pattern matching all files.

Fixes #66 
