### PR TITLE
deps(github-actions): Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -86,7 +86,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.27.0
+        uses: github/codeql-action/upload-sarif@v3.27.1
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -120,12 +120,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.27.0
+        uses: github/codeql-action/init@v3.27.1
         with:
           languages: python
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.27.0
+        uses: github/codeql-action/analyze@v3.27.1
 
   check-markdown-links:
     name: Check Markdown links
@@ -137,7 +137,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.2
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration to ensure the latest versions of actions are used. The most important changes include updating the versions of `codeql-action` and `action-linkspector`.

Updates to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L89-R89): Updated `github/codeql-action/upload-sarif` from `v3.27.0` to `v3.27.1`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L123-R128): Updated `github/codeql-action/init` from `v3.27.0` to `v3.27.1`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L123-R128): Updated `github/codeql-action/analyze` from `v3.27.0` to `v3.27.1`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L140-R140): Updated `UmbrellaDocs/action-linkspector` from `v1.2.2` to `v1.2.4`.

Fixes #77 
