### PR TITLE
chore: Update Repository Labels

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -2,7 +2,17 @@
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["README.md", "docs/**"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 dependencies:
   - any:
       - changed-files:
@@ -23,13 +33,7 @@ shell:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [
-                ".github/workflows/*",
-                ".github/workflows/**/*",
-                ".github/actions/*",
-                ".github/actions/**/*",
-              ]
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
 scanner:
   - any:
       - changed-files:

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -58,6 +58,9 @@
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Custom
 - color: 00f2de
   name: end-to-end-tests


### PR DESCRIPTION
## Description

This pull request includes updates to the labeling configuration files to improve the categorization of changes based on file types. The most important changes include adding a new label for markdown files and simplifying the glob patterns for GitHub Actions files.

Updates to labeling configuration:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L5-R15): Added a new `markdown` label and updated the file patterns for markdown files to include `*.md` and other specific markdown files.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L26-R36): Simplified the glob patterns for GitHub Actions files to reduce redundancy.
* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR61-R63): Added a new label definition for `markdown` with a description and color.

Fixes #100 