### PR TITLE
chore: Remove Repository Files from GitHub Pages

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -12,8 +12,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    name: Build GitHub Pages
+  run-scanner:
+    name: Run Scanner
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +26,22 @@ jobs:
         run: just run
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      - name: Upload Scanner Results
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          path: scanner-results
+
+  build:
+    name: Build GitHub Pages
+    needs: run-scanner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Scanner Results
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: scanner-results
+      - name: Run LS
+        run: ls
       - name: Build
         uses: actions/jekyll-build-pages@v1.0.13
         with:
@@ -36,8 +52,8 @@ jobs:
           path: "./output"
 
   deploy:
-    needs: build
     name: Deploy to GitHub Pages
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Upload Scanner Results
         uses: actions/upload-artifact@v4.4.3
         with:
-          path: scanner-results
+          path: tech_report.md
 
   build:
     name: Build GitHub Pages

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -41,8 +41,6 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: scanner-results
-      - name: Run LS
-        run: ls
       - name: Build
         uses: actions/jekyll-build-pages@v1.0.13
         with:

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/upload-artifact@v4.4.3
         with:
           path: tech_report.md
+          name: scanner-results
 
   build:
     name: Build GitHub Pages


### PR DESCRIPTION
# Pull Request

## Description

This pull request modifies the GitHub Actions workflow to include a new job for running a scanner before building and deploying GitHub Pages. The changes ensure that the scanner results are uploaded and then used during the build process.

Key changes in the workflow:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL15-R16): Renamed the `build` job to `run-scanner` and added steps to upload scanner results.
* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR29-R43): Added a new `build` job that depends on the `run-scanner` job and includes steps to download scanner results before building.
* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL39-R55): Updated the `deploy` job to depend on the `build` job.

Fixes #105
