### PR TITLE
build: Rename tech_report.md to index.md

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -26,10 +26,12 @@ jobs:
         run: just run
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      - name: Rename Scanner Results
+        run: mv tech_report.md index.md
       - name: Upload Scanner Results
         uses: actions/upload-artifact@v4.4.3
         with:
-          path: tech_report.md
+          path: index.md
           name: scanner-results
 
   build:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy-to-github-pages.yml` file. The change renames the scanner results file from `tech_report.md` to `index.md` before uploading it.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR29-R34): Renamed `tech_report.md` to `index.md` in the scanner results section.

Fixes #59
