### PR TITLE
build: Run GitHub Pages Deployment Regularly 

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/workflows/deploy-to-github-pages.yml` file to add a scheduled job that runs daily at midnight.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR8-R9): Added a cron schedule to run the workflow daily at midnight.

Fixes #102 
