### PR TITLE
ci: Add Linkinator Link Testing

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -65,3 +65,20 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
+
+  link-tests:
+    name: Link Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Run Link Tests
+        uses: JustinBeckwith/linkinator-action@v1.11.0
+        with:
+          paths: https://jackplowman.github.io/source_scan
+          recurse: true
+          timeout: 1000
+          markdown: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an addition to the GitHub Actions workflow configuration in the `.github/workflows/deploy-to-github-pages.yml` file. The most important change is the addition of a new job to run link tests after deployment.

### Workflow Enhancements:

* Added a new job `link-tests` to run link tests using the `JustinBeckwith/linkinator-action@v1.11.0` action. This job checks the deployed site for broken links and ensures all links are functional.

Fixes #84 
