### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
@@ -20,7 +23,10 @@ updates:
     commit-message:
       prefix: "deps(python)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to modify the update schedules for dependencies. The most important changes are:

Update schedule changes:

* Changed the update schedule for GitHub Actions dependencies from daily to weekly, specifying Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml` - [.github/dependabot.ymlL11-R14](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R14))
* Changed the update schedule for Python dependencies from monthly to weekly, specifying Saturday at 01:00 in the Europe/London timezone. (`.github/dependabot.yml` - [.github/dependabot.ymlL23-R29](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L23-R29))

Fixes #116 