### PR TITLE
chore: Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change specifies that Dependabot should also consider "patch" and "minor" update types for GitHub Actions.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R20-R22): Added "patch" and "minor" to the `update-types` for GitHub Actions.

Fixes #118 