### PR TITLE
build: Force Log Colours

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -28,6 +28,7 @@ jobs:
         run: just run
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          FORCE_COLOR: true
       - name: Rename Scanner Results
         run: mv tech_report.md index.md
       - name: Upload Scanner Results


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/deploy-to-github-pages.yml` file. The change adds an environment variable to force color output during the run.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR31): Added the `FORCE_COLOR` environment variable to ensure colored output in the GitHub Actions workflow.

Fixes #133
