### PR TITLE
ci: Enforce Deployment Concurrency

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}
+
 permissions:
   contents: write
   pages: write


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/deploy-to-github-pages.yml`. The change adds a concurrency control group to the workflow.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR11-R13): Added a `concurrency` group to ensure that only one instance of the workflow runs at a time.

Fixes #137 
