### PR TITLE
build: Add GitHub Action Summary

### DIFF
--- a/scanner/utils/tests/test_write_markdown.py
+++ b/scanner/utils/tests/test_write_markdown.py
@@ -43,9 +43,7 @@ def test_write_output_file(mock_markdown_file: MagicMock) -> None:
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(
-        content["summary"]
-    )
+    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
     mock_markdown_file.return_value.write.assert_called_once_with("tech_report.md")
 
 
@@ -84,12 +82,8 @@ def test_write_output_file__github_summary(mock_markdown_file: MagicMock) -> Non
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(
-        content["summary"]
-    )
-    mock_markdown_file.return_value.write.assert_has_calls(
-        [call("tech_report.md"), call("test.md")]
-    )
+    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
+    mock_markdown_file.return_value.write.assert_has_calls([call("tech_report.md"), call("test.md")])
     # Cleanup
     del environ["GITHUB_STEP_SUMMARY"]
 
@@ -124,9 +118,7 @@ class TestMarkdownFile:
             (["\n\n"], True),
         ],
     )
-    def test_check_last_line_is_empty(
-        self, lines_of_content: list[str], expected_result: bool
-    ) -> None:
+    def test_check_last_line_is_empty(self, lines_of_content: list[str], expected_result: bool) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -165,9 +157,7 @@ class TestMarkdownFile:
             ("Test", ["Test \n\n"], ["Test \n\n", "Test \n\n"]),
         ],
     )
-    def test_add_paragraph(
-        self, paragraph: str, lines_of_content: list[str], expected_result: list[str]
-    ) -> None:
+    def test_add_paragraph(self, paragraph: str, lines_of_content: list[str], expected_result: list[str]) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -231,9 +221,7 @@ class TestMarkdownFile:
             ),
         ],
     )
-    def test_add_table(
-        self, table_contents: list[dict], expected_result: list[str]
-    ) -> None:
+    def test_add_table(self, table_contents: list[dict], expected_result: list[str]) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         # Act

--- a/scanner/utils/tests/test_write_markdown.py
+++ b/scanner/utils/tests/test_write_markdown.py
@@ -42,9 +42,7 @@ def test_write_output_file(mock_markdown_file: MagicMock) -> None:
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(
-        content["summary"]
-    )
+    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
     mock_markdown_file.return_value.write.assert_called_once_with("tech_report.md")
 
 
@@ -83,12 +81,8 @@ def test_write_output_file__github_summary(mock_markdown_file: MagicMock) -> Non
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(
-        content["summary"]
-    )
-    mock_markdown_file.return_value.write.assert_has_calls(
-        [call("tech_report.md"), call("test.md")]
-    )
+    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
+    mock_markdown_file.return_value.write.assert_has_calls([call("tech_report.md"), call("test.md")])
     # Cleanup
     del environ["GITHUB_STEP_SUMMARY"]
 
@@ -123,9 +117,7 @@ class TestMarkdownFile:
             (["\n\n"], True),
         ],
     )
-    def test_check_last_line_is_empty(
-        self, lines_of_content: list[str], expected_result: bool
-    ) -> None:
+    def test_check_last_line_is_empty(self, lines_of_content: list[str], expected_result: bool) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -164,9 +156,7 @@ class TestMarkdownFile:
             ("Test", ["Test \n\n"], ["Test \n\n", "Test \n\n"]),
         ],
     )
-    def test_add_paragraph(
-        self, paragraph: str, lines_of_content: list[str], expected_result: list[str]
-    ) -> None:
+    def test_add_paragraph(self, paragraph: str, lines_of_content: list[str], expected_result: list[str]) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -230,9 +220,7 @@ class TestMarkdownFile:
             ),
         ],
     )
-    def test_add_table(
-        self, table_contents: list[dict], expected_result: list[str]
-    ) -> None:
+    def test_add_table(self, table_contents: list[dict], expected_result: list[str]) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         # Act

--- a/scanner/utils/tests/test_write_markdown.py
+++ b/scanner/utils/tests/test_write_markdown.py
@@ -11,6 +11,7 @@ FILE_PATH = "source_scan.scanner.utils.write_markdown"
 @patch(f"{FILE_PATH}.MarkdownFile")
 def test_write_output_file(mock_markdown_file: MagicMock) -> None:
     # Arrange
+    del environ["GITHUB_STEP_SUMMARY"]
     content = {
         "summary": [
             {"technology": "Markdown", "count": 1},
@@ -42,7 +43,9 @@ def test_write_output_file(mock_markdown_file: MagicMock) -> None:
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
+    mock_markdown_file.return_value.add_table.assert_called_once_with(
+        content["summary"]
+    )
     mock_markdown_file.return_value.write.assert_called_once_with("tech_report.md")
 
 
@@ -81,8 +84,12 @@ def test_write_output_file__github_summary(mock_markdown_file: MagicMock) -> Non
             call(level=2, title="Summary"),
         ]
     )
-    mock_markdown_file.return_value.add_table.assert_called_once_with(content["summary"])
-    mock_markdown_file.return_value.write.assert_has_calls([call("tech_report.md"), call("test.md")])
+    mock_markdown_file.return_value.add_table.assert_called_once_with(
+        content["summary"]
+    )
+    mock_markdown_file.return_value.write.assert_has_calls(
+        [call("tech_report.md"), call("test.md")]
+    )
     # Cleanup
     del environ["GITHUB_STEP_SUMMARY"]
 
@@ -117,7 +124,9 @@ class TestMarkdownFile:
             (["\n\n"], True),
         ],
     )
-    def test_check_last_line_is_empty(self, lines_of_content: list[str], expected_result: bool) -> None:
+    def test_check_last_line_is_empty(
+        self, lines_of_content: list[str], expected_result: bool
+    ) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -156,7 +165,9 @@ class TestMarkdownFile:
             ("Test", ["Test \n\n"], ["Test \n\n", "Test \n\n"]),
         ],
     )
-    def test_add_paragraph(self, paragraph: str, lines_of_content: list[str], expected_result: list[str]) -> None:
+    def test_add_paragraph(
+        self, paragraph: str, lines_of_content: list[str], expected_result: list[str]
+    ) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         markdown_file.lines_of_content = lines_of_content
@@ -220,7 +231,9 @@ class TestMarkdownFile:
             ),
         ],
     )
-    def test_add_table(self, table_contents: list[dict], expected_result: list[str]) -> None:
+    def test_add_table(
+        self, table_contents: list[dict], expected_result: list[str]
+    ) -> None:
         # Arrange
         markdown_file = MarkdownFile()
         # Act

--- a/scanner/utils/write_markdown.py
+++ b/scanner/utils/write_markdown.py
@@ -20,6 +20,7 @@ def write_output_file(tech_report: TechReport) -> None:
     markdown_file.add_header(level=2, title="Summary")
     markdown_file.add_table(tech_report["summary"])
     markdown_file.write("tech_report.md")
+
     if "GITHUB_STEP_SUMMARY" in environ:
         logger.debug("Running in GitHub Actions, generating action summary")
         markdown_file.write(environ["GITHUB_STEP_SUMMARY"])

--- a/scanner/utils/write_markdown.py
+++ b/scanner/utils/write_markdown.py
@@ -9,7 +9,7 @@ from .types import TechReport
 logger: stdlib.BoundLogger = get_logger()
 
 
-def write_output_files(tech_report: TechReport) -> None:
+def write_output_file(tech_report: TechReport) -> None:
     """Write the tech report to a markdown file.
 
     Args:

--- a/scanner/utils/write_markdown.py
+++ b/scanner/utils/write_markdown.py
@@ -1,3 +1,4 @@
+from os import environ
 from pathlib import Path
 from typing import Self
 
@@ -8,33 +9,36 @@ from .types import TechReport
 logger: stdlib.BoundLogger = get_logger()
 
 
-def write_output_file(tech_report: TechReport) -> None:
+def write_output_files(tech_report: TechReport) -> None:
     """Write the tech report to a markdown file.
 
     Args:
         tech_report (TechReport): The tech report to write to a file.
     """
-    markdown_file = MarkdownFile(file_path="tech_report.md")
+    markdown_file = MarkdownFile()
     markdown_file.add_header(level=1, title="Tech Report")
     markdown_file.add_header(level=2, title="Summary")
     markdown_file.add_table(tech_report["summary"])
-    markdown_file.write()
+    markdown_file.write("tech_report.md")
+    if "GITHUB_STEP_SUMMARY" in environ:
+        logger.debug("Running in GitHub Actions, generating action summary")
+        markdown_file.write(environ["GITHUB_STEP_SUMMARY"])
+    else:
+        logger.debug("Not running in GitHub Actions, skipping generating action summary")
 
 
 class MarkdownFile:
     """Generate a markdown file."""
 
-    file_path: str
     lines_of_content: list[str]
 
-    def __init__(self: Self, file_path: str) -> None:
+    def __init__(self: Self) -> None:
         """Initialise the markdown file."""
-        self.file_path = file_path
         self.lines_of_content = []
 
-    def write(self: Self) -> None:
+    def write(self: Self, file_path: str) -> None:
         """Write the content to the markdown file."""
-        with Path(self.file_path).open("w", encoding="utf-8") as file:
+        with Path(file_path).open("w", encoding="utf-8") as file:
             file.writelines(self.lines_of_content)
 
     def _check_last_line_is_empty(self: Self) -> bool:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant changes to the `scanner/utils/write_markdown.py` and its associated test file to improve the handling of markdown file writing and add support for GitHub Actions summaries. The most important changes include modifying the `MarkdownFile` class to remove the `file_path` attribute, updating the `write_output_file` function to handle GitHub Actions, and adjusting the test cases to reflect these changes.

Improvements to `MarkdownFile` class:

* [`scanner/utils/write_markdown.py`](diffhunk://#diff-345a5890da136100ba010968680627ae688839d4d186f1bf3191c1df15ad069fR1): Removed the `file_path` attribute from the `MarkdownFile` class and updated the `write` method to accept `file_path` as a parameter. [[1]](diffhunk://#diff-345a5890da136100ba010968680627ae688839d4d186f1bf3191c1df15ad069fR1) [[2]](diffhunk://#diff-345a5890da136100ba010968680627ae688839d4d186f1bf3191c1df15ad069fL17-R42)

Enhancements to GitHub Actions support:

* [`scanner/utils/write_markdown.py`](diffhunk://#diff-345a5890da136100ba010968680627ae688839d4d186f1bf3191c1df15ad069fL17-R42): Updated the `write_output_file` function to check for the `GITHUB_STEP_SUMMARY` environment variable and write the summary to the specified file if running in GitHub Actions.

Updates to test cases:

* [`scanner/utils/tests/test_write_markdown.py`](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L37-R111): Modified test cases to remove the `file_path` parameter from `MarkdownFile` initialization and update the `write` method calls with the new parameter. [[1]](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L37-R111) [[2]](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L79-R130) [[3]](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L104-R153) [[4]](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L118-R171) [[5]](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071L182-R237)
* [`scanner/utils/tests/test_write_markdown.py`](diffhunk://#diff-b69dfeeddcdeb2d19f21e2ede9823f430bd7fce0d49f1971dd5ea9401385e071R1): Added a new test case `test_write_output_file__github_summary` to verify the correct behavior of `write_output_file` when the `GITHUB_STEP_SUMMARY` environment variable is set.

Fixes #123 
