### PR TITLE
ci: Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -145,8 +145,8 @@ jobs:
       - name: Check Justfile Format
         run: just just-format-check
 
-  run-code-limit:
-    name: Run Code Limit
+  run-codelimit:
+    name: Run CodeLimit
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -156,5 +156,31 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: "Run Code Limit"
+      - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor
+

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -183,4 +183,3 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
-


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes modifications to the `.github/workflows/code-checks.yml` file to add a new job and correct an existing job name. The most important changes include renaming the `run-code-limit` job and adding a new job for checking GitHub Actions using `zizmor`.

Changes in job configurations:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L148-R148): Renamed the job `run-code-limit` to `run-codelimit` to correct the job name.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R161-R186): Added a new job `run-zizmor` to check GitHub Actions with `zizmor`, including steps for repository checkout, installing `uv`, running `zizmor`, and uploading the SARIF file.

Fixes #152 
