### PR TITLE
chore: Fix Zizmor warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,13 +11,13 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write
-  security-events: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -66,6 +66,8 @@ jobs:
   upload-ruff-analysis-results:
     name: Upload Ruff Analysis Results
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -110,6 +112,8 @@ jobs:
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,9 +23,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.0
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Check Python Code for Dead Code (Vulture)
@@ -69,6 +71,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Check Python Code Quality (Ruff)
@@ -78,7 +81,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.27.6
+        uses: github/codeql-action/upload-sarif@v3.28.0
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -89,6 +92,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Run Unit Tests
@@ -107,13 +113,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.27.6
+        uses: github/codeql-action/init@v3.28.0
         with:
           languages: python
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.27.6
+        uses: github/codeql-action/analyze@v3.28.0
 
   check-markdown-links:
     name: Check Markdown links
@@ -123,6 +132,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
@@ -140,6 +150,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Just
         uses: extractions/setup-just@v2
       - name: Check Justfile Format
@@ -156,6 +167,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
 
@@ -171,7 +183,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4.2.0
+        uses: astral-sh/setup-uv@v5.1.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -179,7 +191,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.27.9
+        uses: github/codeql-action/upload-sarif@v3.28.0
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   run-scanner:
     name: Run Scanner
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -45,6 +47,10 @@ jobs:
     name: Build GitHub Pages
     needs: run-scanner
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -71,6 +77,9 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
       - name: Run Scanner
@@ -50,6 +51,7 @@ jobs:
         with:
           sparse-checkout: .github/github_pages_jekyll_config.yml
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Add Jekyll Config
         run: mv .github/github_pages_jekyll_config.yml _config.yml
       - name: Get Scanner Results
@@ -86,6 +88,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run Link Tests
         uses: JustinBeckwith/linkinator-action@v1.11.0
         with:

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   check-pull-request-title:
@@ -21,6 +20,8 @@ jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -49,5 +49,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.5.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,11 @@ jobs:
       pull-requests: write
     timeout-minutes: 60
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Release Please
         uses: googleapis/release-please-action@v4.1.3
         id: release

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Sync labels
         uses: micnncim/action-label-syncer@v1.3.0
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,13 +7,15 @@ on:
     paths:
       - .github/other-configurations/labels.yml
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   configure-labels:
+    name: Configure Labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes various updates to the GitHub Actions workflows to improve security and performance. The changes primarily involve updating action versions, modifying permissions, and adding the `persist-credentials` parameter to the `checkout` action.

### Updates to GitHub Actions workflows:

* `.github/workflows/code-checks.yml`: 
  * Updated `super-linter` action from `v7.2.0` to `v7.2.1`, `codeql-action` from `v3.27.6` to `v3.28.0`, and `setup-uv` from `v4.2.0` to `v5.1.0`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L14-R29) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L81-R86) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L174-R198)
  * Added `persist-credentials: false` to multiple `checkout` steps to enhance security. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R52) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R69-R76) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R97-R99) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R115-R129) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R139) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R157) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R174)

* `.github/workflows/deploy-to-github-pages.yml`:
  * Adjusted permissions for `contents`, `pages`, and `id-token` to be more restrictive initially and then re-enabled them as needed within specific jobs. [[1]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL15-R30) [[2]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR50-R60) [[3]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR80-R82)
  * Added `persist-credentials: false` to `checkout` steps to improve security.

* `.github/workflows/pull-request-tasks.yml`:
  * Updated permissions for `pull-requests` to be more restrictive initially and then re-enabled them within specific jobs. [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL9) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR23-R24)
  * Added `persist-credentials: false` to `checkout` steps to enhance security.

* `.github/workflows/release-please.yml`:
  * Added `persist-credentials: false` and `fetch-depth: 0` to `checkout` steps to improve security and performance.

* `.github/workflows/sync-labels.yml`:
  * Adjusted permissions to be more restrictive initially and then re-enabled them within specific jobs.
  * Added `persist-credentials: false` to `checkout` steps to enhance security.

Fixes #157
