### PR TITLE
ci: Add run-scanner Job

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      scanner_debug:
+        type: choice
+        description: Turn on debug mode for the scanner
+        required: true
+        options:
+        - false
+        - true
   schedule:
     - cron: "0 0 * * *"
 
@@ -35,6 +43,7 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
+          DEBUG: ${{ github.event.inputs.scanner_debug }}
       - name: Rename Scanner Results
         run: mv tech_report.md index.md
       - name: Upload Scanner Results

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -11,10 +11,13 @@ on:
         description: Turn on debug mode for the scanner
         required: true
         options:
-        - false
-        - true
+          - false
+          - true
   schedule:
     - cron: "0 0 * * *"
+
+env:
+  scanner_debug: ${{ github.event.inputs.scanner_debug || 'false' }}
 
 concurrency:
   group: ${{ github.workflow }}
@@ -43,7 +46,7 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
-          DEBUG: ${{ github.event.inputs.scanner_debug }}
+          DEBUG: ${{ env.scanner_debug }}
       - name: Rename Scanner Results
         run: mv tech_report.md index.md
       - name: Upload Scanner Results

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -7,17 +7,12 @@ on:
   workflow_dispatch:
     inputs:
       scanner_debug:
-        type: choice
-        description: Turn on debug mode for the scanner
-        required: true
-        options:
-          - false
-          - true
+        description: 'Turn on debug mode for the scanner'
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * *"
-
-env:
-  scanner_debug: ${{ github.event.inputs.scanner_debug || 'false' }}
 
 concurrency:
   group: ${{ github.workflow }}
@@ -46,7 +41,7 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
-          DEBUG: ${{ env.scanner_debug }}
+          DEBUG: ${{ inputs.scanner_debug }}
       - name: Rename Scanner Results
         run: mv tech_report.md index.md
       - name: Upload Scanner Results

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      scanner_debug:
-        description: "Turn on debug mode for the scanner"
-        type: boolean
-        required: false
-        default: false
   schedule:
     - cron: "0 0 * * *"
 
@@ -41,7 +35,6 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
-          DEBUG: ${{ inputs.scanner_debug }}
       - name: Rename Scanner Results
         run: mv tech_report.md index.md
       - name: Upload Scanner Results

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scanner_debug:
-        description: 'Turn on debug mode for the scanner'
+        description: "Turn on debug mode for the scanner"
         type: boolean
         required: false
         default: false

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -1,4 +1,3 @@
-
 name: "Run Scanner"
 
 on:

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_GHA_7: Debug input only affects logging verbosity, not build output
 name: "Run Scanner"
 
 on:

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -1,9 +1,6 @@
-name: Deploy to GitHub Pages
+name: "Run Scanner"
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       scanner_debug:
@@ -11,11 +8,6 @@ on:
         type: boolean
         required: false
         default: false
-  schedule:
-    - cron: "0 0 * * *"
-
-concurrency:
-  group: ${{ github.workflow }}
 
 permissions:
   contents: read

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      scanner_debug:
+        description: "Turn on debug mode for the scanner"
+        type: boolean
+        required: false
+        default: false
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  run-scanner:
+    name: Run Scanner
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+      - name: Run Scanner
+        run: just run
+        env:
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          FORCE_COLOR: true
+          DEBUG: ${{ inputs.scanner_debug }}
+      - name: Rename Scanner Results
+        run: mv tech_report.md index.md
+      - name: Upload Scanner Results
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          path: index.md
+          name: scanner-results

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -1,9 +1,10 @@
-#checkov:skip=CKV_GHA_7: Debug input only affects logging verbosity, not build output
+
 name: "Run Scanner"
 
 on:
   workflow_dispatch:
     inputs:
+      #checkov:skip=CKV_GHA_7: Debug input only affects logging verbosity, not build output
       scanner_debug:
         description: "Turn on debug mode for the scanner"
         type: boolean

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -3,7 +3,7 @@ name: "Run Scanner"
 on:
   workflow_dispatch:
     inputs:
-      #checkov:skip=CKV_GHA_7: Debug input only affects logging verbosity, not build output
+      # checkov:skip=CKV_GHA_7: Debug input only affects logging verbosity, not build output
       scanner_debug:
         description: "Turn on debug mode for the scanner"
         type: boolean


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to run a scanner. The workflow is designed to handle debug mode, set up dependencies, run the scanner, and upload the results. Below are the most important changes:

New GitHub Actions workflow:

* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dR1-R44): Added a new workflow named "Run Scanner" that includes a `workflow_dispatch` trigger with an optional `scanner_debug` input. The workflow sets read permissions for contents and includes a job to run the scanner on `ubuntu-latest`. The job consists of steps to checkout the repository, set up Python dependencies, run the scanner, rename the results file, and upload the results as an artifact.

Fixes #183
