### PR TITLE
chore: Run Scanner without Test Dependencies

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -1,6 +1,12 @@
 name: "Setup Dependencies"
 description: "Installs dependencies for the project"
 
+inputs:
+  root-only:
+    description: "Whether to only update the root directory"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -14,6 +20,11 @@ runs:
         cache: "poetry"
     - name: Set up Just
       uses: extractions/setup-just@v2
+    - name: Install Poetry Dependencies (Root Only)
+      if: ${{ inputs.root-only }}
+      shell: bash
+      run: just install-root-only
     - name: Install Poetry Dependencies
+      if: ${{ !inputs.root-only }}
       shell: bash
       run: just install

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -30,6 +30,8 @@ jobs:
           persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          root-only: true
       - name: Run Scanner
         run: just run
         env:

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -29,6 +29,8 @@ jobs:
           persist-credentials: false
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          root-only: true
       - name: Run Scanner
         run: just run
         env:

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,10 @@
 install:
     poetry install
 
+# Install application python dependencies only
+install-root-only:
+    poetry install --only-root
+
 # Run the scanner
 run:
     poetry run python -m scanner


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces changes to the setup and installation process for project dependencies, particularly focusing on the ability to install only root-level dependencies. The most important changes include updates to the GitHub Actions workflow files and the `Justfile`.

### Updates to GitHub Actions:

* [`.github/actions/setup-dependencies/action.yml`](diffhunk://#diff-41744aaf34820b46fe17d53d97ac7b6e435996a46c06a1781154ead9701846daR4-R9): Added a new input parameter `root-only` to control whether only root-level dependencies are installed.
* [`.github/actions/setup-dependencies/action.yml`](diffhunk://#diff-41744aaf34820b46fe17d53d97ac7b6e435996a46c06a1781154ead9701846daR23-R28): Modified steps to conditionally install dependencies based on the `root-only` input.

### Workflow adjustments:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR33-R34): Updated the `Setup Python Dependencies` job to use the `root-only` parameter.
* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dR32-R33): Updated the `Setup Python Dependencies` job to use the `root-only` parameter.

### Justfile changes:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR9-R12): Added a new command `install-root-only` to install only the root-level dependencies using Poetry.

Fixes #182 
