### PR TITLE
build: Replace underscore with space in table headers

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -61,7 +61,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.0
+        uses: github/codeql-action/upload-sarif@v3.28.1
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -109,12 +109,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.0
+        uses: github/codeql-action/init@v3.28.1
         with:
           languages: python
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.0
+        uses: github/codeql-action/analyze@v3.28.1
 
   check-markdown-links:
     name: Check Markdown links
@@ -183,7 +183,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.0
+        uses: github/codeql-action/upload-sarif@v3.28.1
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/scanner/utils/write_markdown.py
+++ b/scanner/utils/write_markdown.py
@@ -74,7 +74,7 @@ class MarkdownFile:
 
     def add_table(self: Self, table_contents: list[dict]) -> None:
         """Add a table to the markdown file."""
-        headers = [header.title() for header in table_contents[0]]
+        headers = [header.replace("_", " ").title() for header in table_contents[0]]
         self.lines_of_content.append("|" + "|".join(headers) + "|\n")
         self.lines_of_content.append(
             "|" + "|".join(["-" * len(header) for header in headers]) + "|\n"


### PR DESCRIPTION
# Pull Request

## Description


This pull request includes updates to the GitHub Actions workflow for code checks and an improvement to the markdown writing utility. The most important changes are:

Updates to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L64-R64): Updated the `github/codeql-action` to version `v3.28.1` for the `upload-sarif`, `init`, and `analyze` steps. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L64-R64) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L112-R117) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L186-R186)

Improvements to markdown writing utility:

* [`scanner/utils/write_markdown.py`](diffhunk://#diff-345a5890da136100ba010968680627ae688839d4d186f1bf3191c1df15ad069fL77-R77): Modified the `add_table` method to replace underscores with spaces in table headers before capitalizing them.

Fixes #191 
