### PR TITLE
chore: Re-Add Markdown Tests to Deployment

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -23,7 +23,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           sparse-checkout: .github/github_pages_jekyll_config.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -22,7 +22,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
@@ -35,10 +35,33 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
           DEBUG: ${{ inputs.scanner_debug }}
-      - name: Rename Scanner Results
-        run: mv tech_report.md index.md
       - name: Upload Scanner Results
         uses: actions/upload-artifact@v4.6.0
         with:
-          path: index.md
+          path: tech_report.md
           name: scanner-results
+
+  markdown-tests:
+    name: Markdown Tests
+    runs-on: ubuntu-latest
+    needs: run-scanner
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Download Scanner Results
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: scanner-results
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+        with:
+          all-dependencies: true
+      - name: Run Markdown Tests
+        run: just markdown-test


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to GitHub Actions workflows, specifically in the `deploy-to-github-pages.yml` and `run-scanner.yml` files. The changes primarily involve renaming steps for clarity and adding a new job to run markdown tests.

Changes to workflow steps:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL26-R26): Renamed the "Checkout" step to "Checkout Repository" for better clarity in three different places. [[1]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL26-R26) [[2]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL55-R55) [[3]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL96-R96)
* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dL25-R25): Renamed the "Checkout" step to "Checkout Repository" for better clarity.

New job addition:

* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dL38-R67): Added a new job named "Markdown Tests" to run markdown tests after the scanner job. This includes steps to checkout the repository, download scanner results, set up Python dependencies, and run the markdown tests.