### PR TITLE
chore: Re-Add Markdown Tests to Deployment 2

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -35,17 +35,40 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
-      - name: Rename Scanner Results
-        run: mv tech_report.md index.md
       - name: Upload Scanner Results
         uses: actions/upload-artifact@v4.6.0
         with:
-          path: index.md
+          path: tech_report.md
           name: scanner-results
+
+  markdown-tests:
+    name: Markdown Tests
+    runs-on: ubuntu-latest
+    needs: run-scanner
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Download Scanner Results
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: scanner-results
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-dependencies
+        with:
+          all-dependencies: true
+      - name: Run Markdown Tests
+        run: just markdown-test
 
   build:
     name: Build GitHub Pages
-    needs: run-scanner
+    needs: markdown-tests
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -64,6 +87,8 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: scanner-results
+      - name: Rename Scanner Results
+        run: mv tech_report.md index.md
       - name: Build
         uses: actions/jekyll-build-pages@v1.0.13
         with:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes significant updates to the GitHub Actions workflow for deploying to GitHub Pages. The changes focus on restructuring the workflow to include a new job for running markdown tests and adjusting the sequence of existing jobs.

Changes to GitHub Actions workflow:

* `.github/workflows/deploy-to-github-pages.yml`: 
  - Removed the step for renaming `tech_report.md` to `index.md` in the `run-scanner` job and updated the artifact upload path to use `tech_report.md` instead of `index.md`.
  - Added a new job `markdown-tests` that includes steps for checking out the repository, downloading scanner results, setting up Python dependencies, and running markdown tests. This job runs after the `run-scanner` job.
  - Updated the `build` job to depend on the new `markdown-tests` job instead of the `run-scanner` job.
  - Moved the step for renaming `tech_report.md` to `index.md` to the `build` job.