### PR TITLE
chore: Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -63,7 +63,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -96,7 +96,7 @@ jobs:
       - name: Override Coverage Source Path for SonarCloud
         run: sed -i "s/<source>\/home\/runner\/work\/source_scan\/source_scan<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/source_scan/source_scan/coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -117,13 +117,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.1
+        uses: github/codeql-action/init@v3.28.10
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.1
+        uses: github/codeql-action/analyze@v3.28.10
 
   check-markdown-links:
     name: Check Markdown links
@@ -192,7 +192,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
       - name: Upload Scanner Results
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           path: tech_report.md
           name: scanner-results

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -36,7 +36,7 @@ jobs:
           FORCE_COLOR: true
           DEBUG: ${{ inputs.scanner_debug }}
       - name: Upload Scanner Results
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           path: tech_report.md
           name: scanner-results


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflows to use the latest versions of various actions. The most important changes are:

Updates to `.github/workflows/code-checks.yml`:

* Updated `github/codeql-action/upload-sarif` to version `v3.28.10` [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L66-R66) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L195-R195)
* Updated `SonarSource/sonarqube-scan-action` to version `v5.0.0`
* Updated `github/codeql-action/init` and `github/codeql-action/analyze` to version `v3.28.10`

Updates to other workflows:

* Updated `actions/upload-artifact` to version `v4.6.1` in `.github/workflows/deploy-to-github-pages.yml`
* Updated `actions/upload-artifact` to version `v4.6.1` in `.github/workflows/run-scanner.yml`