### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@v5.2.2
+      uses: astral-sh/setup-uv@vd4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.2.2
       with:
         pyproject-file: "pyproject.toml"
         enable-cache: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -97,7 +97,7 @@ jobs:
       - name: Override Coverage Source Path for SonarCloud
         run: sed -i "s/<source>\/home\/runner\/work\/source_scan\/source_scan<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/source_scan/source_scan/coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -155,7 +155,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -172,7 +172,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@v1
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
 
   run-zizmor:
     name: Check GitHub Actions with zizmor

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -124,7 +124,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Link Tests
-        uses: JustinBeckwith/linkinator-action@v1.11.0
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: https://jackplowman.github.io/source_scan
           recurse: true

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Pull Request Title
-        uses: deepakputhraya/action-pr-title@v1.0.2
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
@@ -30,7 +30,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
@@ -56,6 +56,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.5.0
+        uses: actions/dependency-review-action@v4.6.0
         with:
           comment-summary-in-pr: on-failure

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use specific commit hashes for the referenced actions, ensuring reproducibility and security. The changes primarily involve pinning dependencies to specific versions across various workflows.

### Dependency Pinning Updates:

* [`.github/actions/setup-dependencies/action.yml`](diffhunk://#diff-41744aaf34820b46fe17d53d97ac7b6e435996a46c06a1781154ead9701846daL14-R14): Updated `astral-sh/setup-uv` action to a specific commit hash (`vd4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`) while retaining version `v5.2.2`.

* `.github/workflows/code-checks.yml`:
  - Updated `super-linter/super-linter/slim` to commit `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2` for version `v7.3.0`.
  - Updated `SonarSource/sonarqube-scan-action` to commit `aa494459d7c39c106cc77b166de8b4250a32bb97` for version `v5.1.0`.
  - Updated `UmbrellaDocs/action-linkspector` to commit `a0567ce1c7c13de4a2358587492ed43cab5d0102` for version `v1.3.4`.
  - Updated `extractions/setup-just` to commit `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` for version `v3`.
  - Updated `getcodelimit/codelimit-action` to commit `a036c6897be9ccf69cde9dfe50eafa8cd79c98f8` for version `v1`.

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL127-R127): Updated `JustinBeckwith/linkinator-action` to commit `3d5ba091319fa7b0ac14703761eebb7d100e6f6d` for version `v1.11.0`.

* `.github/workflows/pull-request-tasks.yml`:
  - Updated `deepakputhraya/action-pr-title` to commit `3864bebc79c5f829d25dd42d3c6579d040b0ef16` for version `v1.0.2`.
  - Updated `pascalgn/size-label-action` to commit `f8edde36b3be04b4f65dcfead05dc8691b374348` for version `v0.5.5`.
  - Updated `actions/dependency-review-action` to version `v4.6.0` (no commit hash provided).

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L26-R26): Updated `micnncim/action-label-syncer` to commit `3abd5ab72fda571e69fffd97bd4e0033dd5f495c` for version `v1.3.0`.