### PR TITLE
chore: Remove CodeQL Configuration File

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -122,7 +122,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.10
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes a custom CodeQL configuration file and updates the workflow to no longer reference it. These changes simplify the CodeQL setup by relying on default configurations.

### Simplification of CodeQL setup:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the custom CodeQL configuration file, which previously excluded the `actions/unpinned-tag` query.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L125): Updated the workflow to stop referencing the removed CodeQL configuration file, defaulting to the standard query set.