### PR TITLE
ci: Validate Lefthook Configuration

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -197,3 +197,19 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
+
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.2.2
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow for validating Lefthook configurations. The most significant change is the inclusion of the `lefthook-validate` job in the `.github/workflows/code-checks.yml` file.

### Workflow Enhancements:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R201-R216): Added a new `lefthook-validate` job to the workflow. This job checks out the repository, installs the latest version of `uv`, and runs `lefthook validate` to ensure Lefthook configurations are valid.
