### PR TITLE
ci: Add Pinact Verify Job

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -213,3 +213,17 @@ jobs:
           version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"

--- a/Justfile
+++ b/Justfile
@@ -140,6 +140,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.3
+min_version: 1.11.11
 colors: true
 
 output:
@@ -20,3 +20,5 @@ pre-commit:
       run: just zizmor-check
     Ruff Checks:
       run: just ruff-checks
+    Pinact Checks:
+      run: just pinact-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ test = [
 ]
 
 [tool.uv]
-required-version = "0.6.14"
+required-version = "0.6.16"
 package = false
 
 [tool.ruff]


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the integration of the Pinact tool into the project for dependency verification and updates several configurations to support its usage. It also includes minor updates to existing tools and workflows.

### Pinact Integration:

* Added a new configuration file `.github/other-configurations/pinact.yml` for Pinact, specifying the schema and defining ignored actions.
* Updated `.github/workflows/code-checks.yml` to include a new `pinact-verify` job for verifying dependencies using Pinact.
* Added Pinact-related commands (`pinact-run`, `pinact-check`, `pinact-update`) to `Justfile` for running, verifying, and updating dependencies.
* Updated `lefthook.yml` to include a `Pinact Checks` pre-commit hook, which runs the `pinact-check` command.

### Tool and Workflow Updates:

* Bumped the minimum version of Lefthook in `lefthook.yml` from `1.11.3` to `1.11.11`.
* Updated the `required-version` of `uv` in `pyproject.toml` from `0.6.14` to `0.6.16`.
