### PR TITLE
ci: Remove SonarCloud Coverage Path Override

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -94,8 +94,6 @@ jobs:
           all-dependencies: "true"
       - name: Run Unit Tests
         run: just unit-test
-      - name: Override Coverage Source Path for SonarCloud
-        run: sed -i "s/<source>\/home\/runner\/work\/source_scan\/source_scan<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/source_scan/source_scan/coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes an unnecessary step from the GitHub Actions workflow for code checks, simplifying the pipeline.

Workflow simplification:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L97-L98): Removed the step that overrides the coverage source path for SonarCloud, as it is no longer needed.