### PR TITLE
chore: Check UV Lock

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -68,6 +68,8 @@ jobs:
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
+      - name: UV Lock Check
+        run: just uv-lock-check
       - name: Check Python Code Format (Ruff)
         run: just ruff-format
         env:

--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,10 @@ run:
 run-with-defaults:
     DEBUG=true GITHUB_REPOSITORY_OWNER=JackPlowman just run
 
+# Check UV lock
+uv-lock-check:
+    uv lock --check
+
 # ------------------------------------------------------------------------------
 # Test Commands
 # ------------------------------------------------------------------------------

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,5 @@ pre-commit:
       run: just ruff-checks
     Pinact Checks:
       run: just pinact-check
+    UV Lock Check:
+      run: just uv-lock-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new UV lock verification step to the codebase, ensuring that the UV lock file is properly checked during various stages of the development workflow. The changes span workflow automation, the `Justfile`, and the pre-commit hooks configuration.

### UV Lock Verification Integration:

* **GitHub Actions Workflow**: Added a new "UV Lock Check" step to the `.github/workflows/code-checks.yml` file to ensure UV lock verification is part of the CI pipeline.
* **`Justfile` Update**: Introduced a `uv-lock-check` command in the `Justfile` that runs `uv lock --check` for verifying the UV lock file.
* **Pre-Commit Hook**: Added a "UV Lock Check" step to the `lefthook.yml` pre-commit hooks to enforce UV lock checks during local development.
