### PR TITLE
deps(github-actions): Bump astral-sh/setup-uv to 6.0.1

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -11,10 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.2.2
-      with:
-        pyproject-file: "pyproject.toml"
-        enable-cache: true
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
     - name: Install UV Dependencies

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -208,8 +208,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.2.2
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Run Lefthook Validate
         run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `setup-uv` action to a newer version across multiple files to ensure compatibility with the latest features and improvements.

### Updates to `setup-uv` Action:

* [`.github/actions/setup-dependencies/action.yml`](diffhunk://#diff-41744aaf34820b46fe17d53d97ac7b6e435996a46c06a1781154ead9701846daL14-R14): Updated the `setup-uv` action from version `v5.2.2` to `v6.0.1` to align with the latest release. Removed the `pyproject-file` and `enable-cache` configuration, likely due to changes in the action's interface.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L211-R211): Updated the `setup-uv` action from version `v5.2.2` to `v6.0.1` in the `Install the latest version of uv` step. Removed the `version` parameter, reflecting updates in the action's configuration.