### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -25,7 +25,7 @@ updates:
       prefix: "deps(python)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -25,9 +24,8 @@ updates:
     commit-message:
       prefix: "deps(python)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the scheduling configuration for Dependabot in the `.github/dependabot.yml` file. The changes replace the previous daily schedule with a cron-based schedule for better control over update timing.

**Scheduling updates:**

* Changed the `interval` from `"daily"` to `"cron"` and added a `cronjob` field with the value `"30 7 * * *"` for the `github-actions` updates group. (`.github/dependabot.yml`, [.github/dependabot.ymlL11-R12](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R12))
* Changed the `interval` from `"daily"` to `"cron"` and added a `cronjob` field with the value `"30 7 * * *"` for the `python` updates group. (`.github/dependabot.yml`, [.github/dependabot.ymlL28-R28](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L28-R28))