### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,15 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -26,9 +30,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance the scheduling and grouping of dependency updates. The most important changes include adding a timezone for the cron schedule and refining the grouping criteria for `github-actions` and `python` updates.

Enhancements to scheduling:

* Added a `timezone` field to the `schedule` section, specifying "Europe/London" to ensure the cron job runs in the correct time zone. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R21) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R37)

Refinements to dependency grouping:

* For the `github-actions` group:
  - Introduced an `applies-to` field with the value "version-updates" to specify the scope of updates.
  - Added `exclude-patterns` to exclude updates matching "super-linter/*".
* For the `python` group:
  - Added an `applies-to` field with the value "version-updates" to specify the scope of updates.