### PR TITLE
ci: Swap SuperLinter to Full Version

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,9 +24,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/workflows/code-checks.yml` file. The change updates the GitHub Action for linting the codebase to use the standard `super-linter/super-linter` repository instead of the `super-linter/super-linter/slim` variant.

* Workflow update:
  * [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L27-R28): Updated the `Lint Code Base` step to use `super-linter/super-linter` instead of `super-linter/super-linter/slim` for consistency and to align with the standard repository.
