### PR TITLE
ci: Bump SuperLinter to 7.4.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,14 +25,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
-          EDITORCONFIG_FILE_NAME: .editorconfig-checker.json
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the linter configuration in the GitHub Actions workflow to use a newer version of the `super-linter` and removes an unused environment variable.

Changes to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L28-L35): Updated `super-linter` to version `7.4.0` by changing the commit hash in the `uses` field.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L28-L35): Removed the `EDITORCONFIG_FILE_NAME` environment variable, as it is no longer required.
