### PR TITLE
feat: Exclude Private Repositories

### DIFF
--- a/scanner/utils/github_interactions.py
+++ b/scanner/utils/github_interactions.py
@@ -23,7 +23,7 @@ def retrieve_repositories() -> PaginatedList[Repository]:
     github = Github()
     repository_owner = getenv("GITHUB_REPOSITORY_OWNER")
     repositories = github.search_repositories(
-        query=f"user:{repository_owner} archived:false"
+        query=f"user:{repository_owner} archived:false is:public",
     )
     logger.info(
         "Retrieved repositories to analyse",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `retrieve_repositories` function in `scanner/utils/github_interactions.py`. The change ensures that only public repositories are retrieved during the search.

* [`scanner/utils/github_interactions.py`](diffhunk://#diff-40dae3e48e37722006554d3f1db64df58148a03b169aeda6aad8d41bc63d8859L26-R26): Modified the query in the `search_repositories` call to include the `is:public` filter, restricting the results to public repositories.
