### PR TITLE
chore: Set Python Minor Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "scanner"
 dynamic = ["version"]
-requires-python = ">=3.13"
+requires-python = "~=3.13"
 dependencies = ["structlog==25.3.0", "pygithub==2.6.1"]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = ">=3.13, <4"
 
 [[package]]
 name = "beautifulsoup4"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `pyproject.toml` file. The change adjusts the `requires-python` version specification to use a compatible release operator (`~=`) instead of a minimum version operator (`>=`).

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4): Updated `requires-python` from `>=3.13` to `~=3.13` to ensure compatibility with Python 3.13 while allowing patch updates.