### PR TITLE
Fix incorrect table length

### DIFF
--- a/tests/ui/test_website.py
+++ b/tests/ui/test_website.py
@@ -62,4 +62,4 @@ def test_repositories_table(page: Page) -> None:
         "Project Name",
         "Technologies And Frameworks",
     ]
-    assert repositories_table.locator("tr").count() == 34
+    assert repositories_table.locator("tr").count() == 35


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the UI test for the repositories table to reflect a change in the number of rows.

* [`tests/ui/test_website.py`](diffhunk://#diff-3acf2f00d96a9ef81ec7a1b5c7109508abd39dc85da1bf88d79afc5c904fd644L65-R65): Updated the test `test_repositories_table` to assert that the repositories table now contains 35 rows instead of 34.