### PR TITLE
build: Disable Pretty Logging in CI

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
+          CI: true
       - name: Upload Scanner Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -35,6 +35,7 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           FORCE_COLOR: true
           DEBUG: ${{ inputs.scanner_debug }}
+          CI: true
       - name: Upload Scanner Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/scanner/utils/custom_logging.py
+++ b/scanner/utils/custom_logging.py
@@ -1,12 +1,32 @@
 from logging import DEBUG, INFO
 from os import getenv
 
-from structlog import configure, make_filtering_bound_logger
+from structlog import (
+    configure,
+    get_logger,
+    make_filtering_bound_logger,
+    stdlib,
+)
+from structlog import (
+    dev as structlog_dev,
+)
+
+logger: stdlib.BoundLogger = get_logger()
 
 
 def set_up_custom_logging() -> None:
     """Setup custom logging for the application."""
     level = INFO
-    if getenv("DEBUG", "false").lower() == "true":
+    if getenv("INPUT_DEBUG", "false").lower() == "true":
         level = DEBUG
-    configure(wrapper_class=make_filtering_bound_logger(level))
+    if getenv("CI"):
+        configure(
+            processors=[
+                structlog_dev.ConsoleRenderer(
+                    exception_formatter=structlog_dev.plain_traceback
+                ),
+            ],
+            wrapper_class=make_filtering_bound_logger(level),
+        )
+    else:
+        configure(wrapper_class=make_filtering_bound_logger(level))


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces changes to improve logging functionality and ensure consistent behavior in CI workflows. The most important updates include adding the `CI` environment variable to relevant GitHub Actions workflows and enhancing the custom logging setup to handle CI-specific configurations.

### CI Workflow Updates:
* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaR38): Added the `CI` environment variable to the workflow to indicate that the job is running in a continuous integration environment.
* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dR38): Added the `CI` environment variable to the workflow for consistency and to support CI-specific behavior.

### Logging Enhancements:
* [`scanner/utils/custom_logging.py`](diffhunk://#diff-1d7d75bfa8df27d78fd98b615012c28cad98db41a00a5517831d439a6d441faeL4-R31): Updated the logging setup to include a CI-specific configuration using `structlog`'s `ConsoleRenderer` when the `CI` environment variable is present. This ensures better logging output formatting for CI environments. Additionally, replaced the `DEBUG` environment variable with `INPUT_DEBUG` for improved clarity and alignment with other inputs.
