### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the file pattern configuration for documentation labeling. The most notable change is a correction to the spelling of the license file in the `labeller.yml` configuration.

Configuration update:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L28-R28): Changed the documentation label pattern from `"LICENSE"` to `"LICENCE"` to match the correct file name.