### PR TITLE
deps(github-actions): Bump GitHub Actions

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download Scanner Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: scanner-results
       - name: Setup Python Dependencies
@@ -85,7 +85,7 @@ jobs:
       - name: Add Jekyll Config
         run: mv .github/github_pages_jekyll_config.yml _config.yml
       - name: Get Scanner Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: scanner-results
       - name: Rename Scanner Results

--- a/.github/workflows/run-scanner.yml
+++ b/.github/workflows/run-scanner.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download Scanner Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: scanner-results
       - name: Setup Python Dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to use a newer version of the `actions/download-artifact` action. The main change is upgrading from version 4.3.0 to 5.0.0 in all relevant workflow files to ensure compatibility and benefit from the latest improvements.

GitHub Actions version upgrade:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL60-R60): Updated `actions/download-artifact` from v4.3.0 to v5.0.0 in both the "Download Scanner Results" and "Get Scanner Results" steps. [[1]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL60-R60) [[2]](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL88-R88)
* [`.github/workflows/run-scanner.yml`](diffhunk://#diff-b23f2b70f3c0ca075093fcdf8e636a7a731d588ac0f3d562b387140356d8642dL60-R60): Updated `actions/download-artifact` from v4.3.0 to v5.0.0 in the "Download Scanner Results" step.